### PR TITLE
fix: removed redundant sparams declaration in OutputSummary

### DIFF
--- a/src/utils_aux.cc
+++ b/src/utils_aux.cc
@@ -234,8 +234,6 @@ void OutputSummary::operator()() {
                average_oxygen_cancer_cells) = AnalyzeTumor();
       size_t total_num_cells = simulation->GetResourceManager()->GetNumAgents();
 
-
-
       // If a dosage is administred this exact time the numbers are not seen in
       // the resource manager yet because of how BioDynaMo is built
       // therefore we need to add the just added new cells to the statistics

--- a/src/utils_aux.cc
+++ b/src/utils_aux.cc
@@ -234,8 +234,7 @@ void OutputSummary::operator()() {
                average_oxygen_cancer_cells) = AnalyzeTumor();
       size_t total_num_cells = simulation->GetResourceManager()->GetNumAgents();
 
-      const auto* sparams =
-          Simulation::GetActive()->GetParam()->Get<SimParam>();
+
 
       // If a dosage is administred this exact time the numbers are not seen in
       // the resource manager yet because of how BioDynaMo is built


### PR DESCRIPTION
In `OutputSummary::operator()()` in `utils_aux.cc`, `sparams` was declared twice in the same function scope:

First (top of function): const auto* sparams = simulation->GetParam()->Get<SimParam>();

Second declaration (later in same function): const auto* sparams = Simulation::GetActive()->GetParam()->Get<SimParam>();

Just removed the second one that wasn't needed, no logic changes