### PR TITLE
README: point the container setup at bin/start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ cd CARTopiaX
 
 A prebuilt BioDynaMo — with its bundled ROOT — is published as a
 [ci-workflows](https://github.com/compiler-research/ci-workflows) recipe cell,
-so you do not have to build it yourself. `bin/repro --devshell` drops you into a
-persistent container with that BioDynaMo in place, your checkout mounted
-read-write, and [Claude Code](https://claude.com/claude-code) installed.
+so you do not have to build it yourself. `bin/start` drops you into a persistent
+container with that BioDynaMo in place, your checkout mounted read-write, and
+[Claude Code](https://claude.com/claude-code) installed.
 
 This is the fastest way for a new contributor to get a working environment.
 
@@ -237,69 +237,35 @@ This is the fastest way for a new contributor to get a working environment.
 - **git** and **Python 3** on the host.
 - **~3 GB free** in the Docker VM (~250 MB download, ~800 MB unpacked, plus build space).
 
-`nektos/act` is *not* needed for this flow, which names the environment by its
-cell coordinate. It is only required to name one by CI matrix row instead — that
-form asks `act` to expand the matrix — or to run a whole CI job locally with
-`bin/repro <row-name>`.
+`nektos/act` is *not* needed. It is only required to run a whole CI job locally
+with `bin/repro <row-name>`, which asks `act` to expand the matrix.
 
 > On Apple Silicon the container is x86_64 and runs translated. That is fine for
 > developing, but do not trust it for timing measurements or for diagnosing
 > toolchain-level failures.
 
-### One-time host setup
+### Getting in
 
 ```bash
 git clone https://github.com/compiler-research/ci-workflows ~/sources/ci-workflows
-
-# Optional: seed the AI state the container symlinks in. Anything here is what
-# Claude sees, and it survives container rebuilds and machine moves. Claude's
-# per-project memory directory is created for you on first entry.
-HOST_CACHE=~/.cache/ci-workflows/devshell-cache
-mkdir -p "$HOST_CACHE/ai/skills"
-cp -r ~/.claude/skills/.      "$HOST_CACHE/ai/skills/"       2>/dev/null || true
-cp    ~/.claude/settings.json "$HOST_CACHE/ai/settings.json" 2>/dev/null || true
+cd ~/sources/ci-workflows && ./bin/start
 ```
 
-### Each session
-
-```bash
-cd /path/to/CARTopiaX        # this directory becomes /patches inside, read-write
-
-~/sources/ci-workflows/bin/repro --devshell --devshell-host-cache \
-    biodynamo/<version>/ubuntu-24.04/x86_64
-```
-
-Take `<version>` from `recipe-version` in
-[`.github/workflows/ci.yml`](.github/workflows/ci.yml) so your environment matches
-what CI uses. Flags must come **before** the cell coordinate — anything after it
-is forwarded to `act` instead.
+Pick CARTopiaX from the list. It clones the project, downloads the BioDynaMo
+build CI uses, installs its host dependencies and opens a shell. Already have a
+checkout? Run `~/sources/ci-workflows/bin/start` from inside it and the menu is
+skipped.
 
 The first entry downloads and unpacks BioDynaMo; later entries take seconds.
-`claude` is installed on entry; log in once per container.
+`claude` is installed for you — log in once per container. A host that has never
+run Claude Code needs nothing extra; if you *do* already run it, anything you
+put in `~/.cache/ci-workflows/devshell-cache/ai/skills` is what it sees inside.
 
-The first entry also prints
-
-```
-::warning title=devshell::the recipe's cmake configure failed; the devshell is still usable.
-```
-
-That is expected and does not affect anything below. `bin/repro` tries to
-configure *BioDynaMo's own* source tree as a convenience, and the base image
-lacks the packages that needs — see
-[Modifying BioDynaMo itself](#modifying-biodynamo-itself) if you want that tree.
-
-### Inside the container
+### Building, inside the container
 
 ```bash
-# 1. BioDynaMo's host dependencies (installed once; they persist with the container)
-sudo apt-get update -qq
-sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l apt-get install -y \
-  libopenmpi-dev libomp-dev libnuma-dev libblas-dev liblapack-dev libgit2-dev g++-11
-
-# 2. BioDynaMo's environment
 source "$DEVSHELL_INSTALL/bin/thisbdm.sh"
 
-# 3. Build and test CARTopiaX
 cd /patches
 cmake . -B build -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
@@ -307,36 +273,16 @@ cmake --build build -j"$(nproc)"
 ctest --test-dir build --output-on-failure
 ```
 
-Two of those are workarounds rather than preferences, so do not drop them:
-
-- **Step 1** is needed because the devshell installs only what an LLVM recipe
-  requires. Without it, CMake stops at
-  `We did not find any OpenMPI installation`.
-- **The compiler pin in step 3** is needed because the devshell exports
-  `CC=clang`, while BioDynaMo replaces the compiler with MPI's wrapper (which
-  wraps gcc) *after* CMake has detected clang. The OpenMP flags then disagree and
-  g++ rejects `-fopenmp=libomp`.
+The compiler pin is a workaround rather than a preference, so do not drop it:
+the devshell exports `CC=clang`, while BioDynaMo replaces the compiler with
+MPI's wrapper (which wraps gcc) *after* CMake has detected clang. The OpenMP
+flags then disagree and g++ rejects `-fopenmp=libomp`.
 
 ### Modifying BioDynaMo itself
 
-The recipe ships BioDynaMo's source next to the install, at `$DEVSHELL_SRC`
-(a shallow checkout at the tag CI pins). Building it needs one thing beyond
-step 1 above: BioDynaMo requires the exact CPython minor that the bundled ROOT
-built its bindings against — 3.9, which no Ubuntu LTS carries.
-
-```bash
-sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l \
-  apt-get install -y --no-install-recommends software-properties-common
-sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l \
-  add-apt-repository -y ppa:deadsnakes/ppa
-sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l apt-get update -qq
-sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l \
-  apt-get install -y --no-install-recommends python3.9 python3.9-dev
-```
-
-Re-launch the devshell once afterwards and it configures `$DEVSHELL_BUILD` with
-the recipe's own cmake flags; from then on `make -C $DEVSHELL_BUILD` iterates
-normally.
+The recipe ships BioDynaMo's source next to the install, at `$DEVSHELL_SRC` —
+a shallow checkout at the tag CI pins, already configured at `$DEVSHELL_BUILD`,
+so `make -C $DEVSHELL_BUILD` iterates directly.
 
 To build CARTopiaX against your modified BioDynaMo, install it to a prefix of
 your own and source *that* instead of `$DEVSHELL_INSTALL`:
@@ -358,19 +304,12 @@ the pristine CI environment one `source` away.
 | layer | holds | survives |
 |---|---|---|
 | container `devshell-<cell>` | apt packages, Claude login, your `$HOME` | exiting the shell |
-| host cache `~/.cache/ci-workflows/devshell-cache` | BioDynaMo install and source, ccache, Claude skills/settings/memory | `--devshell-rm` |
-| `/patches` | **your checkout** | everything — it is your working copy |
+| host cache `~/.cache/ci-workflows/devshell-cache` | BioDynaMo install and source, ccache, Claude skills/settings/memory | removing the container |
+| your checkout | **your work** | everything — it is your working copy |
 
-Your work is never inside the container: `/patches` *is* your repository, so
-commit and push from the host as usual.
-
-Mounts are fixed when the container is created, so always launch from the same
-project directory. To switch projects, remove the container first:
-
-```bash
-~/sources/ci-workflows/bin/repro --devshell --devshell-rm \
-    biodynamo/<version>/ubuntu-24.04/x86_64
-```
+Your work is never inside the container: `/patches` *is* your checkout, so
+commit, push and open pull requests from the host as usual. No GitHub
+credentials are copied into the container.
 
 ---
 


### PR DESCRIPTION
The container section told a contributor to look up a cell coordinate in ci.yml, pass it to bin/repro with two flags in the right order, and then apt-install BioDynaMo's dependencies by hand before anything would configure. Every one of those steps was ci-workflows detail leaking into a biology repository's README.

ci-workflows now installs a recipe's host dependencies itself and ships bin/start, which picks the project from a list and provisions from there, so the setup is one command and the manual apt step is gone. The compiler pin stays: the devshell exports CC=clang while BioDynaMo swaps in MPI's gcc wrapper after CMake has detected the compiler, and that is not fixed yet.